### PR TITLE
Updating examples to use pages_show_list

### DIFF
--- a/examples/db/Facebook Login/3 - Requesting Additional Permissions.html
+++ b/examples/db/Facebook Login/3 - Requesting Additional Permissions.html
@@ -11,7 +11,7 @@
 document.getElementById('login-btn').onclick = function() {
   FB.login(function(response) {
     Log.info('FB.login response', response);
-  }, {scope: 'email, manage_pages'});
+  }, {scope: 'email, pages_show_list'});
   return false;
 }
 </script>


### PR DESCRIPTION
Currently, the "additional permissions" example requests for 'manage_pages', which is no longer a valid permission. Changing to pages_show_list, so we can link the URL directly for users to use, without them needing to make modifications to the repl.