### PR TITLE
revert bug in multi-OD resolution when fetching SDK URL with server env

### DIFF
--- a/rellenv/context.go
+++ b/rellenv/context.go
@@ -211,7 +211,8 @@ func (c *Env) Copy() *Env {
 func (c *Env) SdkURL() string {
 	server := "connect.facebook.net"
 	if c.Env != "" {
-		server = fmt.Sprintf("connect.%s.facebook.net", c.Env)
+		// Necessary for multiple-OD resolution
+		server = fburl.Hostname("static", c.Env) + "/assets.php"
 	}
 	return fmt.Sprintf("https://%s/%s/sdk.js", server, c.locale)
 }


### PR DESCRIPTION
# Summary

Identified potential reversion with commit [237c2a5](https://github.com/fbsamples/fbrell/commit/237c2a57f70ef339dfa5d866cbb35761eb46d551#diff-ab9df7d0d166f54a5e9efeba105aec477f9e97e64e7b193c44d632a2e75b491dL198-L199) in changing SDK URL domain change

# Bug Details

Opening multiple ODs would cause issue where only one OD was supported. This, worst-case, could basically 'deadlock' attempts to utilize FBRell on ODs (not going into how here).

# Test Plan

Load SDK on multiple OD overrides